### PR TITLE
Reading and versioning

### DIFF
--- a/DataLoader.cs
+++ b/DataLoader.cs
@@ -249,7 +249,14 @@ namespace ModShardLauncher
             dialog.ShowDialog();
             await t;
             await LoadFile(DataPath, true);
-            ModLoader.LoadFiles();
+            try
+            {
+                ModLoader.LoadFiles();
+            }
+            catch(Exception ex)
+            {
+                Log.Error(ex, "Something went wrong");
+            }
             if (Main.Settings.SavePos == "")
             {
                 MessageBoxResult result = MessageBox.Show(Application.Current.FindResource("SavePath").ToString(),

--- a/FilePacker.cs
+++ b/FilePacker.cs
@@ -31,8 +31,9 @@ namespace ModShardLauncher
             Write(fs, "MSLM");
             Log.Information("Writting header...");
             
-            string version = DataLoader.GetVersion();
-            Write(fs, version);
+            Assembly assembly = Assembly.GetExecutingAssembly() ?? throw new NullReferenceException("ExecutingAssembly");
+            string mod_version = "v" + FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion;
+            Write(fs, mod_version);
             Log.Information("Writting version...");
 
             Write(fs, textures.Length);

--- a/Main.xaml.cs
+++ b/Main.xaml.cs
@@ -40,7 +40,14 @@ namespace ModShardLauncher
                 Directory.CreateDirectory(ModLoader.ModPath);
             if (!Directory.Exists(ModLoader.ModSourcesPath))
                 Directory.CreateDirectory(ModLoader.ModSourcesPath);
-            ModLoader.LoadFiles();
+            try
+            {
+                ModLoader.LoadFiles();
+            }
+            catch(Exception ex)
+            {
+                Log.Error(ex, "Something went wrong");
+            }
             Settings.LoadSettings();
             SettingsPage = new Settings();
             InitializeComponent();
@@ -66,10 +73,17 @@ namespace ModShardLauncher
         {
             ModPage = new ModInfos();
             ModSourcePage = new ModSourceInfos();
-            var settingCache = new Settings();
+            Settings settingCache = new();
             settingCache.Viewer.Content = SettingsPage.Viewer.Content;
             SettingsPage = settingCache;
-            ModLoader.LoadFiles();
+            try
+            {
+                ModLoader.LoadFiles();
+            }
+            catch(Exception ex)
+            {
+                Log.Error(ex, "Something went wrong");
+            }
             if (Viewer.Content is ModInfos) Viewer.Content = ModPage;
             else if (Viewer.Content is ModSourceInfos) Viewer.Content = ModSourcePage;
             else if (Viewer.Content is Settings) Viewer.Content = SettingsPage;

--- a/ModShardLauncher.csproj
+++ b/ModShardLauncher.csproj
@@ -9,6 +9,7 @@
     <ApplicationIcon>ico.ico</ApplicationIcon>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 	  <SatelliteResourceLanguages>zh-Hans</SatelliteResourceLanguages>
+    <FileVersion>0.9.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup> <!-- Include the specific files to exclude the ones in the test folder -->

--- a/Mods/Mod.cs
+++ b/Mods/Mod.cs
@@ -19,6 +19,7 @@ namespace ModShardLauncher.Mods
         public virtual string Description { get => "未知"; }
         public virtual string ShortDesc { get => "未知"; }
         public virtual string Version { get => "v0.0.0.0"; }
+        public virtual string TargetVersion { get => "v0.0.0.0"; }
         public List<Weapon> ModWeapons;
         public ModFile ModFiles;
         public Mod() { }

--- a/Mods/ModSources.xaml.cs
+++ b/Mods/ModSources.xaml.cs
@@ -29,11 +29,6 @@ namespace ModShardLauncher.Mods
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
-            if(DataLoader.data == null)
-            {
-                MessageBox.Show(Application.Current.FindResource("LoadDataWarning").ToString());
-                return;
-            }
             try
             {
                 FilePacker.Pack((DataContext as ModSource).Path);
@@ -43,7 +38,14 @@ namespace ModShardLauncher.Mods
                 Log.Error(ex, "Something went wrong");
             }
 
-            ModLoader.LoadFiles();
+            try
+            {
+                ModLoader.LoadFiles();
+            }
+            catch(Exception ex)
+            {
+                Log.Error(ex, "Something went wrong");
+            }
         }
     }
 }

--- a/Mods/SourceBar.xaml.cs
+++ b/Mods/SourceBar.xaml.cs
@@ -29,12 +29,6 @@ namespace ModShardLauncher.Mods
 
         private void CompileButton_Click(object sender, RoutedEventArgs e)
         {
-            if (DataLoader.data == null)
-            {
-                MessageBox.Show(Application.Current.FindResource("LoadDataWarning").ToString());
-                return;
-            }
-
             try
             {
                 FilePacker.Pack((DataContext as ModSource).Path);
@@ -44,7 +38,6 @@ namespace ModShardLauncher.Mods
                 Log.Error(ex, "Something went wrong");
             }
             
-            ModLoader.LoadFiles();
             (Main.Instance.Viewer.Content as UserControl).UpdateLayout();
             Main.Instance.Refresh();
         }


### PR DESCRIPTION
- Error handling to catch the read crash at start
- sml files are now packed with the fileversion of msl instead of the game version
- filereader can now read up to 24 bytes of version (to ensure backward compatibility)
- delete the double read after a compilation
- Mod class has a new targetversion field, so modders can tell at which game version the mod was built in the first place
- remove the need of load a data.win before packing a sml file
- Handle the exception on mod loader
- set the fileversion of msl at 0.9.0.0 since we are closed to release