### PR TITLE
Improve msl stability

### DIFF
--- a/Controls/MyToggleButton.xaml.cs
+++ b/Controls/MyToggleButton.xaml.cs
@@ -21,31 +21,33 @@ namespace ModShardLauncher.Controls
     /// </summary>
     public partial class MyToggleButton : UserControl
     {
-        public MyToggleButton()
-        {
-            InitializeComponent();
-        }
         public ImageSource ImageSource { get; set; }
-        public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
-            "Text",
-            typeof(string),
-            typeof(MyToggleButton),
-            new PropertyMetadata(default(string), OnTextChanged));
-        private static void OnTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-        }
         public string Text { get; set; }
         [Category("Behavior")]
         public event EventHandler Checked;
         public event EventHandler Click;
+        public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
+            "Text",
+            typeof(string),
+            typeof(MyToggleButton),
+            new PropertyMetadata(default(string), OnTextChanged)
+        );
+        public MyToggleButton()
+        {
+            InitializeComponent();
+        }
+        private static void OnTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            
+        }
         private void MyButton_Checked(object sender, RoutedEventArgs e)
         {
-            if(Checked != null) Checked.Invoke(this, e);
+            Checked?.Invoke(this, e);
         }
 
         private void MyButton_Click(object sender, RoutedEventArgs e)
         {
-            if (Click != null) Click.Invoke(this, e);
+            Click?.Invoke(this, e);
         }
     }
 }

--- a/DataLoader.cs
+++ b/DataLoader.cs
@@ -17,7 +17,6 @@ namespace ModShardLauncher
     public class DataLoader
     {
         public static UndertaleData data = new();
-        public static UndertaleData dataCache = new();
         internal static string dataPath = "";
         public delegate void FileMessageEventHandler(string message);
         public static event FileMessageEventHandler FileMessageEvent;
@@ -83,24 +82,6 @@ namespace ModShardLauncher
             using (FileStream stream = new(filename, FileMode.Open, FileAccess.Read))
             {
                 data = UndertaleIO.Read(
-                    stream, warning =>
-                    {
-                        ShowWarning(warning, "Loading warning");
-
-                        if (warning.Contains("unserializeCountError.txt")
-                            || warning.Contains("object pool size"))
-                            return;
-
-                        hadWarnings = true;
-                    }, 
-                    delegate (string message)
-                    {
-                        FileMessageEvent?.Invoke(message);
-                    }
-                );
-
-                // TODO: test suppr dataCache
-                dataCache = UndertaleIO.Read(
                     stream, warning =>
                     {
                         ShowWarning(warning, "Loading warning");
@@ -212,8 +193,8 @@ namespace ModShardLauncher
             {
                 try
                 {
-                    IEnumerable<IUndertaleListChunk?> enumerableChunks = data.FORM.Chunks.Values.Select(x => x as IUndertaleListChunk);
-                    Parallel.ForEach(enumerableChunks.Where(x => x is not null), (chunk) =>
+                    IEnumerable<IUndertaleListChunk> enumerableChunks = data.FORM.Chunks.Values.Where(x => x is not null).Select(x => (IUndertaleListChunk)x);
+                    Parallel.ForEach(enumerableChunks, (chunk) =>
                     {
                         chunk.ClearIndexDict();
                     });

--- a/DataLoader.cs
+++ b/DataLoader.cs
@@ -3,29 +3,22 @@ using UndertaleModLib.Models;
 using System.Threading.Tasks;
 using System.IO;
 using System;
-using UndertaleModTool;
 using System.Windows;
-using System.Diagnostics;
-using UndertaleModLib.Decompiler;
-using ModShardLauncher.Mods;
-using System.Text;
-using System.Windows.Threading;
-using UndertaleModLib.ModelsDebug;
 using UndertaleModLib.Util;
 using System.Linq;
 using Microsoft.Win32;
-using System.Windows.Documents;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Serilog;
+using UndertaleModLib.Decompiler;
 
 namespace ModShardLauncher
 {
     public class DataLoader
     {
-        public static UndertaleData data = null;
-        public static UndertaleData dataCache = null;
-        internal static string DataPath = "";
+        public static UndertaleData data = new();
+        public static UndertaleData dataCache = new();
+        internal static string dataPath = "";
         public delegate void FileMessageEventHandler(string message);
         public static event FileMessageEventHandler FileMessageEvent;
         public static void ShowWarning(string warning, string title)
@@ -53,99 +46,125 @@ namespace ModShardLauncher
         }
         public static async Task<bool> DoOpenDialog()
         {
+            // auto load if it can
             if(Main.Settings.LoadPos != "" && File.Exists(Main.Settings.LoadPos))
             {
                 await LoadFile(Main.Settings.LoadPos);
                 return true;
             }
-            OpenFileDialog dlg = new OpenFileDialog();
 
-            dlg.DefaultExt = "win";
-            dlg.Filter = "Game Maker Studio data files (.win, .unx, .ios, .droid, audiogroup*.dat)|*.win;*.unx;*.ios;*.droid;audiogroup*.dat|All files|*";
+            // else open a new dialog
+            OpenFileDialog dlg = new()
+            {
+                DefaultExt = "win",
+                Filter = "Game Maker Studio data files (.win, .unx, .ios, .droid, audiogroup*.dat)|*.win;*.unx;*.ios;*.droid;audiogroup*.dat|All files|*"
+            };
 
+            // load
             if (dlg.ShowDialog() == true)
             {
                 await LoadFile(dlg.FileName);
                 return true;
             }
+
+            // nothing was load
             return false;
+        }
+        private static void ExportData()
+        {
+            File.WriteAllText("json_dump_code.json", JsonConvert.SerializeObject(data.Code.Select(t => t.Name.Content)));
+            File.WriteAllText("json_dump_variables.json", JsonConvert.SerializeObject(data.Variables.Select(t => t.Name.Content)));
+            File.WriteAllText("json_dump_rooms.json", JsonConvert.SerializeObject(data.Rooms.Select(t => t.Name.Content)));
+            Msl.GenerateNRandomLinesFromCode(data.Code, new GlobalDecompileContext(data, false), 100, 1, 0);
+        }
+        private static bool LoadUmt(string filename)
+        {
+            bool hadWarnings = false;
+            using (FileStream stream = new(filename, FileMode.Open, FileAccess.Read))
+            {
+                data = UndertaleIO.Read(
+                    stream, warning =>
+                    {
+                        ShowWarning(warning, "Loading warning");
+
+                        if (warning.Contains("unserializeCountError.txt")
+                            || warning.Contains("object pool size"))
+                            return;
+
+                        hadWarnings = true;
+                    }, 
+                    delegate (string message)
+                    {
+                        FileMessageEvent?.Invoke(message);
+                    }
+                );
+
+                // TODO: test suppr dataCache
+                dataCache = UndertaleIO.Read(
+                    stream, warning =>
+                    {
+                        ShowWarning(warning, "Loading warning");
+
+                        if (warning.Contains("unserializeCountError.txt")
+                            || warning.Contains("object pool size"))
+                            return;
+
+                        hadWarnings = true;
+                    }, 
+                    delegate (string message)
+                    {
+                        FileMessageEvent?.Invoke(message);
+                    }
+                );
+            }
+
+            UndertaleEmbeddedTexture.TexData.ClearSharedStream();
+            Log.Information(string.Format("Successfully load: {0}.", filename));
+
+            return hadWarnings;
         }
         public static async Task LoadFile(string filename, bool re = false)
         {
+            // save the filename for later
+            dataPath = filename;
+            // create a new dialog box
             LoadingDialog dialog = new()
             {
                 Owner = Main.Instance
             };
-            DataPath = filename;
-            Task t = Task.Run(() =>
+            // task load a data.win with umt
+            Task taskLoadDataWinWithUmt = Task.Run(() =>
             {
                 bool hadWarnings = false;
                 try
                 {
-                    using (FileStream stream = new(filename, FileMode.Open, FileAccess.Read))
-                    {
-                        data = UndertaleIO.Read(
-                            stream, warning =>
-                            {
-                                ShowWarning(warning, "Loading warning");
-
-                                if (warning.Contains("unserializeCountError.txt")
-                                    || warning.Contains("object pool size"))
-                                    return;
-
-                                hadWarnings = true;
-                            }, 
-                            delegate (string message)
-                            {
-                                FileMessageEvent?.Invoke(message);
-                            }
-                        );
-
-                        File.WriteAllText("json_dump_code.json", JsonConvert.SerializeObject(data.Code.Select(t => t.Name.Content)));
-                        File.WriteAllText("json_dump_variables.json", JsonConvert.SerializeObject(data.Variables.Select(t => t.Name.Content)));
-                        File.WriteAllText("json_dump_rooms.json", JsonConvert.SerializeObject(data.Rooms.Select(t => t.Name.Content)));
-                        // GenericUtils.GenerateNRandomLinesFromCode(data.Code, new GlobalDecompileContext(data, false), 100, 1, 0);
-
-                        dataCache = UndertaleIO.Read(
-                            stream, warning =>
-                            {
-                                ShowWarning(warning, "Loading warning");
-
-                                if (warning.Contains("unserializeCountError.txt")
-                                    || warning.Contains("object pool size"))
-                                    return;
-
-                                hadWarnings = true;
-                            }, 
-                            delegate (string message)
-                            {
-                                FileMessageEvent?.Invoke(message);
-                            }
-                        );
-                    }
-
-                    UndertaleEmbeddedTexture.TexData.ClearSharedStream();
-                    Log.Information(string.Format("Successfully load: {0}.", filename));
+                    hadWarnings = LoadUmt(filename);
                 }
                 catch (Exception ex)
                 {   
                     Log.Error(ex, "Something went wrong");
                     throw;
                 }
-                Main.Instance.Dispatcher.Invoke(async () =>
+                Main.Instance.Dispatcher.Invoke(() =>
                 {
                     dialog.Hide();
                 });
             });
-
+            // run
             dialog.ShowDialog();
-            await t;
+            await taskLoadDataWinWithUmt;
             ModLoader.Initalize();
+            
             if(Main.Settings.LoadPos == "" && !re)
             {
-                MessageBoxResult result = MessageBox.Show(Application.Current.FindResource("LoadPath").ToString(),
-                        Application.Current.FindResource("LoadPath").ToString(), MessageBoxButton.YesNo, MessageBoxImage.Question);
-                if(result == MessageBoxResult.Yes)
+                MessageBoxResult result = MessageBox.Show(
+                    Application.Current.FindResource("LoadPath").ToString(),
+                    Application.Current.FindResource("LoadPath").ToString(), 
+                    MessageBoxButton.YesNo, 
+                    MessageBoxImage.Question
+                );
+
+                if (result == MessageBoxResult.Yes)
                 {
                     Main.Settings.LoadPos = filename;
                 }
@@ -171,65 +190,77 @@ namespace ModShardLauncher
                 await SaveFile(dlg.FileName);
                 return true;
             }
-            // else await LoadFile(DataPath, true);
+
             return false;
+        }
+        private static void SaveTempWithUmt(string filename)
+        {
+            using (FileStream stream = new(filename + "temp", FileMode.Create, FileAccess.Write))
+            {
+                UndertaleIO.Write(stream, data, message =>
+                {
+                    FileMessageEvent?.Invoke(message);
+                });
+            }
+
+            UndertaleEmbeddedTexture.TexData.ClearSharedStream();
+            QoiConverter.ClearSharedBuffer();
+        }
+        private static void HandleFailedSave(Exception exception)
+        {
+            if (!UndertaleIO.IsDictionaryCleared)
+            {
+                try
+                {
+                    IEnumerable<IUndertaleListChunk?> enumerableChunks = data.FORM.Chunks.Values.Select(x => x as IUndertaleListChunk);
+                    Parallel.ForEach(enumerableChunks.Where(x => x is not null), (chunk) =>
+                    {
+                        chunk.ClearIndexDict();
+                    });
+
+                    UndertaleIO.IsDictionaryCleared = true;
+                }
+                catch { }
+            }
+
+            Main.Instance.Dispatcher.Invoke(() =>
+            {
+                ShowError("An error occured while trying to save:\n" + exception.Message, "Save error");
+            });
         }
         public static async Task SaveFile(string filename)
         {
+            // create a new dialog
             LoadingDialog dialog = new()
             {
                 Owner = Main.Instance
             };
-            Task t = Task.Run(async () =>
+
+            Task t = Task.Run(() =>
             {
                 bool SaveSucceeded = true;
+                // try temp save first
                 try
                 {
-                    using (FileStream stream = new(filename + "temp", FileMode.Create, FileAccess.Write))
-                    {
-                        UndertaleIO.Write(stream, data, message =>
-                        {
-                            FileMessageEvent?.Invoke(message);
-                        });
-                    }
-
-                    UndertaleEmbeddedTexture.TexData.ClearSharedStream();
-                    QoiConverter.ClearSharedBuffer();
+                    SaveTempWithUmt(filename);
                 }
                 catch (Exception e)
                 {
-                    if (!UndertaleIO.IsDictionaryCleared)
-                    {
-                        try
-                        {
-                            IEnumerable<IUndertaleListChunk?> listChunks = data.FORM.Chunks.Values.Select(x => x as IUndertaleListChunk);
-                            Parallel.ForEach(listChunks.Where(x => x is not null), (chunk) =>
-                            {
-                                chunk.ClearIndexDict();
-                            });
-
-                            UndertaleIO.IsDictionaryCleared = true;
-                        }
-                        catch { }
-                    }
-                    Main.Instance.Dispatcher.Invoke(() =>
-                    {
-                        ShowError("An error occured while trying to save:\n" + e.Message, "Save error");
-                    });
+                    HandleFailedSave(e);
                     SaveSucceeded = false;
                 }
+
+                // move save
                 try
                 {
                     if (SaveSucceeded)
                     {
-                        if (File.Exists(filename))
-                            File.Delete(filename);
+                        if (File.Exists(filename)) File.Delete(filename);
                         File.Move(filename + "temp", filename);
                     }
                     else
                     {
-                        if (File.Exists(filename + "temp"))
-                            File.Delete(filename + "temp");
+                        if (File.Exists(filename + "temp")) File.Delete(filename + "temp");
                     }
                 }
                 catch (Exception exc)
@@ -241,26 +272,27 @@ namespace ModShardLauncher
 
                     SaveSucceeded = false;
                 }
+
                 Main.Instance.Dispatcher.Invoke(() =>
                 {
                     dialog.Hide();
                 });
             });
+
+            //run
             dialog.ShowDialog();
             await t;
-            await LoadFile(DataPath, true);
-            try
-            {
-                ModLoader.LoadFiles();
-            }
-            catch(Exception ex)
-            {
-                Log.Error(ex, "Something went wrong");
-            }
+            await LoadFile(dataPath, true);
+
             if (Main.Settings.SavePos == "")
             {
-                MessageBoxResult result = MessageBox.Show(Application.Current.FindResource("SavePath").ToString(),
-                        Application.Current.FindResource("SavePath").ToString(), MessageBoxButton.YesNo, MessageBoxImage.Question);
+                MessageBoxResult result = MessageBox.Show(
+                    Application.Current.FindResource("SavePath").ToString(),
+                    Application.Current.FindResource("SavePath").ToString(), 
+                    MessageBoxButton.YesNo, 
+                    MessageBoxImage.Question
+                );
+
                 if (result == MessageBoxResult.Yes)
                 {
                     Main.Settings.SavePos = filename;

--- a/Extensions/ModShard.cs
+++ b/Extensions/ModShard.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UndertaleModLib;
+﻿using UndertaleModLib;
 using UndertaleModLib.Models;
 
 namespace ModShardLauncher.Extensions
@@ -20,7 +15,7 @@ namespace ModShardLauncher.Extensions
         }
         public void CreateFunc()
         {
-            var ScriptThread = new UndertaleExtensionFunction()
+            UndertaleExtensionFunction ScriptThread = new()
             {
                 Name = DataLoader.data.Strings.MakeString("ScriptThread"),
                 ExtName = DataLoader.data.Strings.MakeString("ScriptThread"),
@@ -30,7 +25,7 @@ namespace ModShardLauncher.Extensions
                 ID = DataLoader.data.ExtensionFindLastId()
             };
             Functions.Add(ScriptThread);
-            var GetScript = new UndertaleExtensionFunction()
+            UndertaleExtensionFunction GetScript = new()
             {
                 Name = DataLoader.data.Strings.MakeString("GetScript"),
                 ExtName = DataLoader.data.Strings.MakeString("GetScript"),
@@ -40,7 +35,7 @@ namespace ModShardLauncher.Extensions
                 ID = ScriptThread.ID + 1
             };
             Functions.Add(GetScript);
-            var PopScript = new UndertaleExtensionFunction()
+            UndertaleExtensionFunction PopScript = new()
             {
                 Name = DataLoader.data.Strings.MakeString("PopScript"),
                 ExtName = DataLoader.data.Strings.MakeString("PopScript"),
@@ -50,7 +45,7 @@ namespace ModShardLauncher.Extensions
                 ID = GetScript.ID + 1
             };
             Functions.Add(PopScript);
-            var RunCallBack = new UndertaleExtensionFunction()
+            UndertaleExtensionFunction RunCallBack = new()
             {
                 Name = DataLoader.data.Strings.MakeString("RunCallBack"),
                 ExtName = DataLoader.data.Strings.MakeString("RunCallBack"),

--- a/FilePacker.cs
+++ b/FilePacker.cs
@@ -31,6 +31,8 @@ namespace ModShardLauncher
             Write(fs, "MSLM");
             Log.Information("Writting header...");
             
+            // work around to find the FileVersion of ModShardLauncher.dll for single file publishing
+            // see: https://github.com/dotnet/runtime/issues/13051
             Assembly assembly = Assembly.GetExecutingAssembly() ?? throw new NullReferenceException("ExecutingAssembly");
             string mod_version = "v" + FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion;
             Write(fs, mod_version);

--- a/FileReader.cs
+++ b/FileReader.cs
@@ -64,7 +64,9 @@ namespace ModShardLauncher
                 if(!Stream.CanRead) Stream = new FileStream(Path, FileMode.Open);
                 Stream.Position = FileOffset;
                 FileReader.Read(Stream, file.offset);
-                return FileReader.Read(Stream, file.length);
+                byte[] fileStream = FileReader.Read(Stream, file.length);
+                Stream.Close();
+                return fileStream;
             }
             throw new FileNotFoundException(string.Format("File {0} not found in the packed sml.", fileName));
         }

--- a/Language/en-us.xaml
+++ b/Language/en-us.xaml
@@ -25,6 +25,7 @@
     <sys:String x:Key="ModVersion">ModVersion</sys:String>
     <sys:String x:Key="GameVersion">MSL Version</sys:String>
     <sys:String x:Key="Compile">Compile</sys:String>
+    <sys:String x:Key="SaveDataWarning">Patching failed, cant save</sys:String>
     <sys:String x:Key="LoadDataWarning">Please load a game data file first!</sys:String>
     <sys:String x:Key="VersionDifferentWarningTitle">Mod version is different from game version</sys:String>
     <sys:String x:Key="VersionDifferentWarning">Mod version is different from game version, maybe it will crash if you load it.Still want to load?</sys:String>

--- a/Main.xaml.cs
+++ b/Main.xaml.cs
@@ -115,24 +115,24 @@ namespace ModShardLauncher
 
         private void MyToggleButton_Click_1(object sender, EventArgs e)
         {
-            if ((bool)(sender as MyToggleButton).MyButton.IsChecked) Viewer.Content = ModPage;
+            if (sender is MyToggleButton button && Msl.ThrowIfNull(button.MyButton.IsChecked)) Viewer.Content = ModPage;
             else Viewer.Content = MainPage;
         }
 
         private void MyToggleButton_Click_2(object sender, EventArgs e)
         {
-            if ((bool)(sender as MyToggleButton).MyButton.IsChecked) Viewer.Content = ModSourcePage;
+            if (sender is MyToggleButton button && Msl.ThrowIfNull(button.MyButton.IsChecked)) Viewer.Content = ModSourcePage;
             else Viewer.Content = MainPage;
         }
         private void MyToggleButton_Click_4(object sender, EventArgs e)
         {
-            if ((bool)(sender as MyToggleButton).MyButton.IsChecked) Viewer.Content = SettingsPage;
+            if (sender is MyToggleButton button && Msl.ThrowIfNull(button.MyButton.IsChecked)) Viewer.Content = SettingsPage;
             else Viewer.Content = MainPage;
         }
         private void MyToggleButton_Click_3(object sender, EventArgs e)
         {
             WindowState = WindowState.Minimized;
-            (sender as MyToggleButton).MyButton.IsChecked = false;
+            if (sender is MyToggleButton button) button.MyButton.IsChecked = false;
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)

--- a/Main.xaml.cs
+++ b/Main.xaml.cs
@@ -21,7 +21,6 @@ namespace ModShardLauncher
     public partial class Main : Window
     {
         public static Main Instance;
-        public UndertaleData Data => DataLoader.data;
         public MainPage MainPage;
         public ModInfos ModPage;
         public ModSourceInfos ModSourcePage;
@@ -44,7 +43,7 @@ namespace ModShardLauncher
             Instance = this;
             MainPage = new MainPage();
             ModPage = new ModInfos();
-            Settings.LoadSettings();
+            UserSettings.LoadSettings();
             ModSourcePage = new ModSourceInfos();
             if (!Directory.Exists(ModLoader.ModPath))
                 Directory.CreateDirectory(ModLoader.ModPath);
@@ -75,10 +74,6 @@ namespace ModShardLauncher
             InitializeComponent();
 
             Viewer.Content = MainPage;
-
-            
-            //Viewer.Content = new DescriptionView(Application.Current.FindResource("Welcome_Use").ToString(),
-            //Application.Current.FindResource("Welcome_Desc").ToString());
         }
 
         private void MyToggleButton_Checked(object sender, EventArgs e)
@@ -152,7 +147,7 @@ namespace ModShardLauncher
         public string SavePos = "";
         public string LoadPos = "";
         public List<string> EnableMods = new();
-        public void LoadSettings()
+        public static void LoadSettings()
         {
             // if no settings file, early stop
             if (!File.Exists("Settings.json")) return;
@@ -160,7 +155,7 @@ namespace ModShardLauncher
             // read file
             string settings = File.ReadAllText("Settings.json");
             // convert if as UserSettings
-            Main.Settings = JsonConvert.DeserializeObject<UserSettings>(settings);
+            Main.Settings = Msl.ThrowIfNull(JsonConvert.DeserializeObject<UserSettings>(settings));
 
             CheckLog(Main.Settings.EnableLogger);
 
@@ -195,7 +190,7 @@ namespace ModShardLauncher
                 Main.lls.MinimumLevel = (LogEventLevel) 1 + (int) LogEventLevel.Fatal;
             }
         }
-        public void ChangeLanguage(int index)
+        public static void ChangeLanguage(int index)
         {
             ResourceDictionary resDict;
             switch (index)
@@ -219,7 +214,6 @@ namespace ModShardLauncher
                     Main.Settings.Language = "Русский";
                     break;
             }
-            
         }
         public void SaveSettings()
         {

--- a/Main.xaml.cs
+++ b/Main.xaml.cs
@@ -80,9 +80,9 @@ namespace ModShardLauncher
         {
             foreach(var i in stackPanel.Children)
             {
-                if(i != sender && i is MyToggleButton)
+                if(i != sender && i is MyToggleButton button)
                 {
-                    (i as MyToggleButton).MyButton.IsChecked = false;
+                    button.MyButton.IsChecked = false;
                 }
             }
         }

--- a/ModLoader.cs
+++ b/ModLoader.cs
@@ -172,16 +172,19 @@ namespace ModShardLauncher
                     continue;
                 }
                 Main.Settings.EnableMods.Add(mod.Name);
-                string version = DataLoader.GetVersion();
-                Regex reg = new("0([0-9])");
-                version = reg.Replace(version, "$1");
-                if (mod.Version != version)
+
+                // work around to find the FileVersion of ModShardLauncher.dll for single file publishing
+                // see: https://github.com/dotnet/runtime/issues/13051
+                ProcessModule mainProcess = Msl.ThrowIfNull(Process.GetCurrentProcess().MainModule);
+                string mainProcessName = Msl.ThrowIfNull(mainProcess.FileName);
+                string mod_version = "v" + FileVersionInfo.GetVersionInfo(mainProcessName).FileVersion;
+
+                if (mod.Version != mod_version)
                 {
                     MessageBoxResult result = MessageBox.Show(
                         Application.Current.FindResource("VersionDifferentWarning").ToString(),
                         Application.Current.FindResource("VersionDifferentWarningTitle").ToString() + " : " + mod.Name, 
-                        MessageBoxButton.YesNo, 
-                        MessageBoxImage.Question
+                        MessageBoxButton.OK
                     );
                     if (result == MessageBoxResult.No) continue;
                 }

--- a/ModLoader.cs
+++ b/ModLoader.cs
@@ -215,14 +215,6 @@ namespace ModShardLauncher
             PatchMods();
             SetTable(Weapons, "gml_GlobalScript_table_weapons");
             SetTable(WeaponDescriptions, "gml_GlobalScript_table_weapons_text");
-            try
-            {
-                LoadFiles();
-            }
-            catch(Exception ex)
-            {
-                Log.Error(ex, "Something went wrong");
-            }
         }
         internal static void PatchInnerFile()
         {

--- a/ModUtils/CodeUtils.cs
+++ b/ModUtils/CodeUtils.cs
@@ -121,9 +121,8 @@ namespace ModShardLauncher
                 ModLoader.Data.Code.Add(code);
                 return code;
             }
-            catch(Exception ex) 
+            catch
             {
-                Log.Error(ex, "Something went wrong");
                 throw;
             }
         }
@@ -146,9 +145,8 @@ namespace ModShardLauncher
                 Log.Information(string.Format("Successfully added the function : {0}", name.ToString()));
                 return scriptCode;
             }
-            catch(Exception ex) 
+            catch 
             {
-                Log.Error(ex, "Something went wrong");
                 throw;
             }
         }

--- a/ModUtils/Weapon.cs
+++ b/ModUtils/Weapon.cs
@@ -43,11 +43,11 @@ namespace ModShardLauncher.Mods
         /// <summary>
         /// 译名列表
         /// </summary>
-        public Dictionary<ModLanguage, string>? NameList;
+        public Dictionary<ModLanguage, string> NameList;
         /// <summary>
         /// 描述翻译列表
         /// </summary>
-        public Dictionary<ModLanguage, string>? WeaponDescriptions;
+        public Dictionary<ModLanguage, string> WeaponDescriptions;
         /// <summary>
         /// 内部ID
         /// </summary>
@@ -350,7 +350,7 @@ namespace ModShardLauncher.Mods
         }
         public void CloneDefaults(string name)
         {
-            var weapon = Msl.GetWeapon(name);
+            Weapon weapon = Msl.GetWeapon(name);
             Set(Weapon2String(weapon).Item1);
         }
 
@@ -360,9 +360,9 @@ namespace ModShardLauncher.Mods
         }
         public void Set(string property)
         {
-            var attributes = property.Split(";").ToList();
+            List<string> attributes = property.Split(";").ToList();
             attributes.RemoveAt(attributes.Count - 1);
-            var str2 =
+            string str2 =
             "Name;ID;Slot;Rare;Material;MaxDuration;Lv;E;Price;Rng;WeaponDamage;ArmorDamage;" +
             "ArmorPiercing;BodypartDamage;SlashingDamage;PiercingDamage;BluntDamage;RendingDamage;" +
             "FireDamage;ShockDamage;PoisonDamage;CausticDamage;FrostDamage;ArcaneDamage;" +
@@ -373,21 +373,23 @@ namespace ModShardLauncher.Mods
             "CryomanticPower;ArcanisticPower;AstromanticPower;PsimanticPower;ChronomanticPower;HealthRestoration;" +
             "Lifesteal;Manasteal;BonusRange;RangeModifier;DamageReceived;DamageReturned;HealingReceived;" +
             "STL;NoiseProduced;Balance;OffhandEfficiency;SlayingChance;tags;NoDrop;";
-            var attributes2 = str2.Split(";").ToList();
+            List<string> attributes2 = str2.Split(";").ToList();
             attributes2.Remove("");
-            foreach (var attr in attributes2)
+            foreach (string attr in attributes2)
             {
                 if (attr == "Name" || attr == "ID") continue;
-                var field = typeof(Weapon).GetField(attr, BindingFlags.Public | BindingFlags.Instance);
-                if (field.FieldType == typeof(string)) field?.SetValue(this, attributes[attributes2.IndexOf(attr)]);
-                else if (attributes[attributes2.IndexOf(attr)] == "") field?.SetValue(this, 0);
-                else field?.SetValue(this, int.Parse(attributes[attributes2.IndexOf(attr)]));
+                FieldInfo? fieldOrNull = typeof(Weapon).GetField(attr, BindingFlags.Public | BindingFlags.Instance);
+                FieldInfo field = Msl.ThrowIfNull(fieldOrNull);
+
+                if (field.FieldType == typeof(string)) field.SetValue(this, attributes[attributes2.IndexOf(attr)]);
+                else if (attributes[attributes2.IndexOf(attr)] == "") field.SetValue(this, 0);
+                else field.SetValue(this, int.Parse(attributes[attributes2.IndexOf(attr)]));
             }
         }
         public static (string, string, string) Weapon2String(Weapon weapon)
         {
-            var type = typeof(Weapon);
-            var str =
+            Type type = typeof(Weapon);
+            string str =
             "Name;ID;Slot;Rare;Material;MaxDuration;Lv;E;Price;Rng;WeaponDamage;ArmorDamage;" +
             "ArmorPiercing;BodypartDamage;SlashingDamage;PiercingDamage;BluntDamage;RendingDamage;" +
             "FireDamage;ShockDamage;PoisonDamage;CausticDamage;FrostDamage;ArcaneDamage;" +
@@ -398,13 +400,17 @@ namespace ModShardLauncher.Mods
             "CryomanticPower;ArcanisticPower;AstromanticPower;PsimanticPower;ChronomanticPower;HealthRestoration;" +
             "Lifesteal;Manasteal;BonusRange;RangeModifier;DamageReceived;DamageReturned;HealingReceived;" +
             "STL;NoiseProduced;Balance;OffhandEfficiency;SlayingChance;tags;NoDrop;";
-            var attributes = str.Split(";").ToList();
+
+            List<string> attributes = str.Split(";").ToList();
             attributes.Remove("");
-            var ret = "";
-            foreach (var attr in attributes)
+            string ret = "";
+
+            foreach (string attr in attributes)
             {
-                var field = type.GetField(attr, BindingFlags.Public | BindingFlags.Instance);
-                var value = field?.GetValue(weapon);
+                FieldInfo? fieldOrNull = type.GetField(attr, BindingFlags.Public | BindingFlags.Instance);
+                FieldInfo field = Msl.ThrowIfNull(fieldOrNull);
+
+                object? value = field.GetValue(weapon);
                 if (value != null)
                 {
                     if((field.FieldType == typeof(int) && (value as int?) != 0) || field.FieldType == typeof(string))
@@ -419,10 +425,10 @@ namespace ModShardLauncher.Mods
         }
         public static Weapon String2Weapon(string property)
         {
-            var weapon = new Weapon();
-            var attributes = property.Split(";").ToList();
+            Weapon weapon = new();
+            List<string> attributes = property.Split(";").ToList();
             attributes.RemoveAt(attributes.Count - 1);
-            var str2 =
+            string str2 =
             "Name;ID;Slot;Rare;Material;MaxDuration;Lv;E;Price;Rng;WeaponDamage;ArmorDamage;" +
             "ArmorPiercing;BodypartDamage;SlashingDamage;PiercingDamage;BluntDamage;RendingDamage;" +
             "FireDamage;ShockDamage;PoisonDamage;CausticDamage;FrostDamage;ArcaneDamage;" +
@@ -433,14 +439,16 @@ namespace ModShardLauncher.Mods
             "CryomanticPower;ArcanisticPower;AstromanticPower;PsimanticPower;ChronomanticPower;HealthRestoration;" +
             "Lifesteal;Manasteal;BonusRange;RangeModifier;DamageReceived;DamageReturned;HealingReceived;" +
             "STL;NoiseProduced;Balance;OffhandEfficiency;SlayingChance;tags;NoDrop;";
-            var attributes2 = str2.Split(";").ToList();
+            List<string> attributes2 = str2.Split(";").ToList();
             attributes2.Remove("");
-            foreach (var attr in attributes2)
+            foreach (string attr in attributes2)
             {
-                var field = typeof(Weapon).GetField(attr, BindingFlags.Public | BindingFlags.Instance);
-                if (field.FieldType == typeof(string)) field?.SetValue(weapon, attributes[attributes2.IndexOf(attr)]);
-                else if (attributes[attributes2.IndexOf(attr)] == "") field?.SetValue(weapon, 0);
-                else field?.SetValue(weapon, int.Parse(attributes[attributes2.IndexOf(attr)]));
+                FieldInfo? fieldOrNull = typeof(Weapon).GetField(attr, BindingFlags.Public | BindingFlags.Instance);
+                FieldInfo field = Msl.ThrowIfNull(fieldOrNull);
+
+                if (field.FieldType == typeof(string)) field.SetValue(weapon, attributes[attributes2.IndexOf(attr)]);
+                else if (attributes[attributes2.IndexOf(attr)] == "") field.SetValue(weapon, 0);
+                else field.SetValue(weapon, int.Parse(attributes[attributes2.IndexOf(attr)]));
             }
             return weapon;
         }

--- a/Mods/DisassemblyEditor.cs
+++ b/Mods/DisassemblyEditor.cs
@@ -9,18 +9,15 @@ namespace ModShardLauncher.Mods
 {
     public class DisassemblyEditor
     {
-        public DisassemblyEditor() { }
         public UndertaleData Data => DataLoader.data;
+        public UndertaleCode Code;
+        public List<string> CodeContents;
+        public int Index { get; private set; } = 0;
         public DisassemblyEditor(UndertaleCode code)
         {
             Code = code;
             CodeContents = code.Disassemble(Data.Variables, Data.CodeLocals.For(Code)).Split("\n").ToList();
         }
-
-        public UndertaleCode Code = new();
-        public List<string> CodeContents = new();
-        public int Index { get; private set; } = 0;
-
         public bool TryGotoNext(Func<string, bool> predicate)
         {
             if (CodeContents.FirstOrDefault(predicate) == default) return false;

--- a/Mods/Mod.cs
+++ b/Mods/Mod.cs
@@ -20,8 +20,8 @@ namespace ModShardLauncher.Mods
         public virtual string ShortDesc { get => "未知"; }
         public virtual string Version { get => "v0.0.0.0"; }
         public virtual string TargetVersion { get => "v0.0.0.0"; }
-        public List<Weapon> ModWeapons;
-        public ModFile ModFiles;
+        public List<Weapon> ModWeapons = new();
+        public ModFile ModFiles = new();
         public Mod() { }
         public virtual void LoadAssembly()
         {

--- a/Mods/ModBar.xaml.cs
+++ b/Mods/ModBar.xaml.cs
@@ -22,11 +22,11 @@ namespace ModShardLauncher.Mods
     /// </summary>
     public partial class ModBar : UserControl
     {
+        public ImageSource? Icon = null;
         public ModBar()
         {
             InitializeComponent();
         }
-        public ImageSource Icon = null;
     }
     public class ByteArrayToImageSourceConverter : IValueConverter
     {
@@ -35,8 +35,8 @@ namespace ModShardLauncher.Mods
             byte[] imageData = (byte[])value;
             if (imageData.Length == 0) return new BitmapImage(new Uri("/Resources/icon_default.png", UriKind.Relative));
 
-            var biImg = new BitmapImage();
-            MemoryStream ms = new MemoryStream(imageData);
+            BitmapImage biImg = new();
+            MemoryStream ms = new(imageData);
             biImg.BeginInit();
             biImg.StreamSource = ms;
             biImg.EndInit();

--- a/Mods/ModSources.xaml.cs
+++ b/Mods/ModSources.xaml.cs
@@ -31,7 +31,7 @@ namespace ModShardLauncher.Mods
         {
             try
             {
-                FilePacker.Pack((DataContext as ModSource).Path);
+                FilePacker.Pack(Msl.ThrowIfNull(DataContext as ModSource).Path);
             }
             catch(Exception ex)
             {

--- a/Mods/SourceBar.xaml.cs
+++ b/Mods/SourceBar.xaml.cs
@@ -31,20 +31,20 @@ namespace ModShardLauncher.Mods
         {
             try
             {
-                FilePacker.Pack(((ModSource)DataContext).Path);
+                FilePacker.Pack(Msl.ThrowIfNull(DataContext as ModSource).Path);
             }
             catch(Exception ex)
             {
                 Log.Error(ex, "Something went wrong");
             }
             
-            (Main.Instance.Viewer.Content as UserControl).UpdateLayout();
+            Msl.ThrowIfNull(Main.Instance.Viewer.Content as UserControl).UpdateLayout();
             Main.Instance.Refresh();
         }
 
         private void OpenButton_Click(object sender, RoutedEventArgs e)
         {
-            System.Diagnostics.Process.Start("explorer.exe", ((ModSource)DataContext).Path);
+            System.Diagnostics.Process.Start("explorer.exe", Msl.ThrowIfNull(DataContext as ModSource).Path);
             
         }
     }

--- a/Mods/SourceBar.xaml.cs
+++ b/Mods/SourceBar.xaml.cs
@@ -31,7 +31,7 @@ namespace ModShardLauncher.Mods
         {
             try
             {
-                FilePacker.Pack((DataContext as ModSource).Path);
+                FilePacker.Pack(((ModSource)DataContext).Path);
             }
             catch(Exception ex)
             {
@@ -44,7 +44,7 @@ namespace ModShardLauncher.Mods
 
         private void OpenButton_Click(object sender, RoutedEventArgs e)
         {
-            System.Diagnostics.Process.Start("explorer.exe", (DataContext as ModSource).Path);
+            System.Diagnostics.Process.Start("explorer.exe", ((ModSource)DataContext).Path);
             
         }
     }

--- a/Pages/GeneralPage.xaml.cs
+++ b/Pages/GeneralPage.xaml.cs
@@ -20,29 +20,25 @@ namespace ModShardLauncher.Pages
         public GeneralPage()
         {
             InitializeComponent();
-            
-            /*
-            var a = Enum.GetValues(typeof(ModLanguage));
-            foreach(var i in a)
-            {
-                Languages.Add(i.ToString());
-            }*/
+
+            // add Languages
             Languages.Add("中文");
             Languages.Add("English");
             //Languages.Add("Русский");
+
             switch (Main.Settings.Language)
             {
                 case "Chinese":
                     LangSelector.SelectedIndex = 0;
-                    Main.Settings.ChangeLanguage(0);
+                    UserSettings.ChangeLanguage(0);
                     break;
                 case "English":
                     LangSelector.SelectedIndex = 1;
-                    Main.Settings.ChangeLanguage(1);
+                    UserSettings.ChangeLanguage(1);
                     break;
                 case "Russian":
                     LangSelector.SelectedIndex = 2;
-                    Main.Settings.ChangeLanguage(2);
+                    UserSettings.ChangeLanguage(2);
                     break;
             }
         }
@@ -58,7 +54,7 @@ namespace ModShardLauncher.Pages
                 return;
             }
             var combo = sender as ComboBox;
-            Main.Settings.ChangeLanguage(combo.SelectedIndex);
+            UserSettings.ChangeLanguage(combo.SelectedIndex);
             selection = combo.SelectedIndex;
             LangSelector.SelectedIndex = selection;
         }

--- a/Pages/GeneralPage.xaml.cs
+++ b/Pages/GeneralPage.xaml.cs
@@ -61,7 +61,7 @@ namespace ModShardLauncher.Pages
 
         private void Logger_Checked(object sender, RoutedEventArgs e)
         {
-            Main.Settings.EnableLogger = (bool)Logger.IsChecked;
+            Main.Settings.EnableLogger = Msl.ThrowIfNull(Logger.IsChecked);
             UserSettings.CheckLog(Main.Settings.EnableLogger);
             Main.Settings.SaveSettings();
         }

--- a/Pages/GeneralPage.xaml.cs
+++ b/Pages/GeneralPage.xaml.cs
@@ -53,7 +53,7 @@ namespace ModShardLauncher.Pages
                 selection = LangSelector.SelectedIndex;
                 return;
             }
-            var combo = sender as ComboBox;
+            ComboBox combo = Msl.ThrowIfNull(sender as ComboBox);
             UserSettings.ChangeLanguage(combo.SelectedIndex);
             selection = combo.SelectedIndex;
             LangSelector.SelectedIndex = selection;

--- a/Pages/ModInfos.xaml.cs
+++ b/Pages/ModInfos.xaml.cs
@@ -43,15 +43,6 @@ namespace ModShardLauncher.Pages
                 Log.Information("Failed patching vanilla");
                 MessageBox.Show(Application.Current.FindResource("SaveDataWarning").ToString());
             }
-
-            try
-            {
-                ModLoader.LoadFiles();
-            }
-            catch(Exception ex)
-            {
-                Log.Error(ex, "Something went wrong");
-            }
             
             Main.Instance.Refresh();
         }

--- a/Pages/ModInfos.xaml.cs
+++ b/Pages/ModInfos.xaml.cs
@@ -25,7 +25,7 @@ namespace ModShardLauncher.Pages
         }
         private async void Save_Click(object sender, EventArgs e)
         {
-            if (DataLoader.data == null)
+            if (DataLoader.data.FORM == null)
             {
                 MessageBox.Show(Application.Current.FindResource("LoadDataWarning").ToString());
                 return;

--- a/Pages/ModInfos.xaml.cs
+++ b/Pages/ModInfos.xaml.cs
@@ -31,11 +31,13 @@ namespace ModShardLauncher.Pages
                 return;
             }
 
+            bool patchSucess = false;
+
             try 
             {
                 ModLoader.PatchFile();
                 Log.Information("Successfully patch vanilla");
-                await DataLoader.DoSaveDialog();
+                patchSucess = true;
             }
             catch(Exception ex)
             {
@@ -43,7 +45,8 @@ namespace ModShardLauncher.Pages
                 Log.Information("Failed patching vanilla");
                 MessageBox.Show(Application.Current.FindResource("SaveDataWarning").ToString());
             }
-            
+
+            if (patchSucess) await DataLoader.DoSaveDialog();
             Main.Instance.Refresh();
         }
     }

--- a/Pages/ModInfos.xaml.cs
+++ b/Pages/ModInfos.xaml.cs
@@ -1,18 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Security.RightsManagement;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using Serilog;
 
 namespace ModShardLauncher.Pages
@@ -22,14 +11,13 @@ namespace ModShardLauncher.Pages
     /// </summary>
     public partial class ModInfos : UserControl
     {
+        public static ModInfos Instance;
+        public List<ModFile> Mods { get; set; } = new();
         public ModInfos()
         {
             InitializeComponent();
             Instance = this;
         }
-        public static ModInfos Instance;
-        public List<ModFile> Mods { get; set; } = new List<ModFile>();
-
         private async void Open_Click(object sender, EventArgs e)
         {
             await DataLoader.DoOpenDialog();
@@ -47,14 +35,24 @@ namespace ModShardLauncher.Pages
             {
                 ModLoader.PatchFile();
                 Log.Information("Successfully patch vanilla");
+                await DataLoader.DoSaveDialog();
             }
             catch(Exception ex)
             {
                 Log.Error(ex, "Something went wrong");
                 Log.Information("Failed patching vanilla");
+                MessageBox.Show(Application.Current.FindResource("SaveDataWarning").ToString());
+            }
+
+            try
+            {
+                ModLoader.LoadFiles();
+            }
+            catch(Exception ex)
+            {
+                Log.Error(ex, "Something went wrong");
             }
             
-            await DataLoader.DoSaveDialog();
             Main.Instance.Refresh();
         }
     }

--- a/Pages/ModSourceInfos.xaml.cs
+++ b/Pages/ModSourceInfos.xaml.cs
@@ -31,11 +31,13 @@ namespace ModShardLauncher.Pages
                 return;
             }
 
+            bool patchSucess = false;
+
             try 
             {
                 ModLoader.PatchFile();
                 Log.Information("Successfully patch vanilla");
-                await DataLoader.DoSaveDialog();
+                patchSucess = true;
             }
             catch(Exception ex)
             {
@@ -44,6 +46,7 @@ namespace ModShardLauncher.Pages
                 MessageBox.Show(Application.Current.FindResource("SaveDataWarning").ToString());
             }
 
+            if (patchSucess) await DataLoader.DoSaveDialog();
             Main.Instance.Refresh();
         }
     }

--- a/Pages/ModSourceInfos.xaml.cs
+++ b/Pages/ModSourceInfos.xaml.cs
@@ -25,7 +25,7 @@ namespace ModShardLauncher.Pages
         }
         private async void Save_Click(object sender, EventArgs e)
         {
-            if (DataLoader.data == null)
+            if (DataLoader.data.FORM == null)
             {
                 MessageBox.Show(Application.Current.FindResource("LoadDataWarning").ToString());
                 return;

--- a/Pages/ModSourceInfos.xaml.cs
+++ b/Pages/ModSourceInfos.xaml.cs
@@ -44,15 +44,6 @@ namespace ModShardLauncher.Pages
                 MessageBox.Show(Application.Current.FindResource("SaveDataWarning").ToString());
             }
 
-            try
-            {
-                ModLoader.LoadFiles();
-            }
-            catch(Exception ex)
-            {
-                Log.Error(ex, "Something went wrong");
-            }
-
             Main.Instance.Refresh();
         }
     }

--- a/Pages/ModSourceInfos.xaml.cs
+++ b/Pages/ModSourceInfos.xaml.cs
@@ -1,17 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using Serilog;
 
 namespace ModShardLauncher.Pages
 {
@@ -20,13 +11,13 @@ namespace ModShardLauncher.Pages
     /// </summary>
     public partial class ModSourceInfos : UserControl
     {
+        public static ModSourceInfos Instance;
+        public List<ModSource> ModSources {  get; set; } = new();
         public ModSourceInfos()
         {
             InitializeComponent();
             Instance = this;
         }
-        public static ModSourceInfos Instance;
-        public List<ModSource> ModSources {  get; set; } = new List<ModSource>();
         private async void Open_Click(object sender, EventArgs e)
         {
             await DataLoader.DoOpenDialog();
@@ -39,8 +30,29 @@ namespace ModShardLauncher.Pages
                 MessageBox.Show(Application.Current.FindResource("LoadDataWarning").ToString());
                 return;
             }
-            ModLoader.PatchFile();
-            DataLoader.DoSaveDialog();
+
+            try 
+            {
+                ModLoader.PatchFile();
+                Log.Information("Successfully patch vanilla");
+                await DataLoader.DoSaveDialog();
+            }
+            catch(Exception ex)
+            {
+                Log.Error(ex, "Something went wrong");
+                Log.Information("Failed patching vanilla");
+                MessageBox.Show(Application.Current.FindResource("SaveDataWarning").ToString());
+            }
+
+            try
+            {
+                ModLoader.LoadFiles();
+            }
+            catch(Exception ex)
+            {
+                Log.Error(ex, "Something went wrong");
+            }
+
             Main.Instance.Refresh();
         }
     }

--- a/Pages/Settings.xaml.cs
+++ b/Pages/Settings.xaml.cs
@@ -7,13 +7,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace ModShardLauncher.Pages
 {
@@ -31,7 +24,8 @@ namespace ModShardLauncher.Pages
 
         private void GeneralSettings_Click(object sender, RoutedEventArgs e)
         {
-            if ((bool)(sender as ToggleButton).IsChecked) Viewer.Content = GeneralPage;
+            bool isChecked = Msl.ThrowIfNull(((ToggleButton)sender).IsChecked);
+            if (isChecked) Viewer.Content = GeneralPage;
             else Viewer.Content = null;
         }
     }


### PR DESCRIPTION
- Improve data.win loading: delete the datacache double load
- During patching, compare the version packed in a sml with the FileVersion instead of the gameversion
- Improve clarity of DataLoader
- If patching failed, the save dialog won't pop up
- A lot of warning fixes