### PR TITLE
Msl cleaning

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: publish
+on:
+  workflow_dispatch: # Allow running the workflow manually from the GitHub UI
+  push:
+    branches:
+      - 'main'       # Run the workflow when pushing to the main branch (test only)
+    tags:
+      - '*'   # Run the workflow with a tag
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  NuGetDirectory: ${{ github.workspace }}/publish
+
+jobs:
+  set_version:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: 
+          fetch-depth: 0
+          ref: main
+
+      - name: Set Version
+        id: package_version
+        uses: KageKirin/set-csproj-version@v0
+        with:
+          file: ./ModShardLauncher.csproj
+          version: ${{ github.ref_name  }}
+
+      - name: Set user info
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Check if there are any changes
+        id: verify_diff
+        run: |
+          git diff --quiet . || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit Files & Pull
+        if: steps.verify_diff.outputs.changed == 'true'
+        run: |
+          git commit -a -m "Updated version with CI."
+          git pull origin main --rebase
+
+      - name: Push Changes
+        if: steps.verify_diff.outputs.changed == 'true'
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+      
+      - name: Get SHA
+        id: sha
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo ${{ steps.sha.outputs.sha }}
+
+  create_msl:
+    runs-on: ubuntu-latest
+    needs: [ set_version ]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Get all history to allow automatic versioning using MinVer
+        ref: ${{ needs.set_version.outputs.sha }}
+
+    # Install the .NET SDK indicated in the global.json file
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+
+    # Build the project in the folder from the environment variable NuGetDirectory
+    - run: dotnet publish -r win-x64 -c Release /p:PublishSingleFile=true /p:IncludeAllContentForSelfExtract=true /p:PublishReadyToRun=true --output ${{ env.NuGetDirectory }}
+
+    # Zip the folder
+    - name: Zip
+      run: zip -r msl.zip ${{ env.NuGetDirectory }}
+
+    # Publish the NuGet package as an artifact, so they can be used in the following jobs
+    - uses: actions/upload-artifact@v3
+      with:
+        name: msl
+        if-no-files-found: error
+        retention-days: 7
+        path: msl.zip
+
+  create_release:
+    runs-on: ubuntu-latest
+    needs: [ create_msl ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        run: gh release create ${{ github.ref_name }} --generate-notes --prerelease
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}

--- a/Controls/ModInfos.xaml.cs
+++ b/Controls/ModInfos.xaml.cs
@@ -41,6 +41,7 @@ namespace ModShardLauncher.Controls
                 ModLoader.PatchFile();
                 Log.Information("Successfully patch vanilla");
                 patchSucess = true;
+                Main.Instance.LogModList();
             }
             catch(Exception ex)
             {

--- a/Controls/ModSourceInfos.xaml.cs
+++ b/Controls/ModSourceInfos.xaml.cs
@@ -38,6 +38,7 @@ namespace ModShardLauncher.Controls
                 ModLoader.PatchFile();
                 Log.Information("Successfully patch vanilla");
                 patchSucess = true;
+                Main.Instance.LogModList();
             }
             catch(Exception ex)
             {

--- a/Controls/SourceBar.xaml.cs
+++ b/Controls/SourceBar.xaml.cs
@@ -31,7 +31,7 @@ namespace ModShardLauncher.Controls
         {
             try
             {
-                FilePacker.Pack(Msl.ThrowIfNull(DataContext as ModSource).Path);
+                UtilsPacker.Pack(Msl.ThrowIfNull(DataContext as ModSource).Path);
             }
             catch(Exception ex)
             {

--- a/DataLoader.cs
+++ b/DataLoader.cs
@@ -104,11 +104,21 @@ namespace ModShardLauncher
             File.WriteAllText("json_preset_catacombs.json", Decompiler.Decompile(data.Code.First(t => t.Name.Content.Contains("scr_preset_catacombs")), context));
             File.WriteAllText("json_preset_crypt.json", Decompiler.Decompile(data.Code.First(t => t.Name.Content.Contains("scr_preset_crypt_1")), context));
         }
+        /// <summary>
+        /// Compute the MD5 checksum of a file located in a FileStream.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <returns></returns>
         private static string ComputeChecksum(FileStream stream)
         {
             using var md5 = MD5.Create();
             return Convert.ToHexString(md5.ComputeHash(stream));
         }
+        /// <summary>
+        /// Return True if the MD5 checksum of a file is equal either to the MD5 checksum of the GOG data.win of Stoneshard or to the MD5 checksum of the STEAM data.win of Stoneshard.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <returns></returns>
         private static bool CompareChecksum(FileStream stream)
         {
             string hash = ComputeChecksum(stream);

--- a/DataLoader.cs
+++ b/DataLoader.cs
@@ -30,21 +30,6 @@ namespace ModShardLauncher
         {
             Console.WriteLine(title + ":" + error);
         }
-        public static string GetVersion()
-        {
-            string version = data.Strings.First(t => t.Content.EndsWith(" Build date: ")).Content;
-            // version is spelled Verison in the code base
-            // so dont touch this part even if it feels like a mistake
-            List<string> sp = version.Replace(" Build date: ", "").Replace("Verison: ", "").Split(".").ToList();
-            List<string> sp2 = new();
-            sp.ForEach(i =>
-            {
-                if (i.Length < 2) sp2.Add(0 + i);
-                else sp2.Add(i);
-            });
-            version = "v" + string.Join(".", sp2);
-            return version;
-        }
         public static async Task<bool> DoOpenDialog()
         {
             // else open a new dialog

--- a/FilePacker.cs
+++ b/FilePacker.cs
@@ -1,285 +1,58 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Emit;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Windows;
 using Serilog;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Diagnostics;
+using ModShardPackerReference;
 
 namespace ModShardLauncher
 {
-    public static class FilePacker
+    public static class UtilsPacker
     {
-        public static void Pack(string path)
+        public static bool Pack(string path)
         {
-            Log.Information(string.Format("Starting packing {0}", path));
-
-            DirectoryInfo dir = new(path);
-            FileInfo[] textures = dir.GetFiles("*.png", SearchOption.AllDirectories);
-            FileInfo[] scripts = dir.GetFiles("*.lua", SearchOption.AllDirectories);
-            FileInfo[] codes = dir.GetFiles("*.gml", SearchOption.AllDirectories);
-            FileInfo[] assemblies = dir.GetFiles("*.asm", SearchOption.AllDirectories);
-            int offset = 0;
-            FileStream fs = new(Path.Join(ModLoader.ModPath, dir.Name + ".sml"), FileMode.Create);
-
-            Write(fs, "MSLM");
-            Log.Information("Writting header...");
-
             // work around to find the FileVersion of ModShardLauncher.dll for single file publishing
             // see: https://github.com/dotnet/runtime/issues/13051
-            ProcessModule mainProcess = Msl.ThrowIfNull(Process.GetCurrentProcess().MainModule);
-            string mainProcessName = Msl.ThrowIfNull(mainProcess.FileName);
-            string mod_version = "v" + FileVersionInfo.GetVersionInfo(mainProcessName).FileVersion;
-            
-            Write(fs, mod_version);
-            Log.Information("Writting version...");
-
-            Write(fs, textures.Length);
-            foreach (FileInfo tex in textures)
+            string mslVersion;
+            try
             {
-                string name = dir.Name + tex.FullName.Replace(path, "");
-                Write(fs, name.Length);
-                Write(fs, name);
-                Write(fs, offset);
-                int len = CalculateBytesLength(tex);
-                Write(fs, len);
-                offset += len;
+                ProcessModule mainProcess = Msl.ThrowIfNull(Process.GetCurrentProcess().MainModule);
+                string mainProcessName = Msl.ThrowIfNull(mainProcess.FileName);
+                mslVersion = "v" + FileVersionInfo.GetVersionInfo(mainProcessName).FileVersion;
             }
-            Log.Information("Preparing textures...");
-
-            Write(fs, scripts.Length);
-            foreach (FileInfo scr in scripts)
+            catch(FileNotFoundException ex)
             {
-                string name = dir.Name + scr.FullName.Replace(path, "");
-                Write(fs, name.Length);
-                Write(fs, name);
-                Write(fs, offset);
-                int len = CalculateBytesLength(scr);
-                Write(fs, len);
-                offset += len;
-                
-            }
-            Log.Information("Preparing scripts...");
-
-            Write(fs, codes.Length);
-            foreach (FileInfo cds in codes)
-            {
-                string name = dir.Name + cds.FullName.Replace(path, "");
-                Write(fs, name.Length);
-                Write(fs, name);
-                Write(fs, offset);
-                int len = CalculateBytesLength(cds);
-                Write(fs, len);
-                offset += len;
-            }
-            Log.Information("Preparing codes...");
-
-            Write(fs, assemblies.Length);
-            foreach (FileInfo asm in assemblies)
-            {
-                string name = dir.Name + asm.FullName.Replace(path, "");
-                Write(fs, name.Length);
-                Write(fs, name);
-                Write(fs, offset);
-                int len = CalculateBytesLength(asm);
-                Write(fs, len);
-                offset += len;
-            }
-            Log.Information("Preparing assemblies...");
-
-            foreach (FileInfo tex in textures)
-                Write(fs, tex);
-            Log.Information("Writting textures...");
-
-            foreach (FileInfo scr in scripts)
-                Write(fs, scr);
-            Log.Information("Writting scripts...");
-
-            foreach (FileInfo cds in codes)
-                Write(fs, cds);
-            Log.Information("Writting codes...");
-
-            foreach (FileInfo asm in assemblies)
-                Write(fs, asm);
-            Log.Information("Writting assemblies...");
-
-            Log.Information("Starting compilation...");
-            bool successful = CompileMod(dir.Name, path, out byte[] code, out _);
-            if (!successful)
-            {
-                fs.Close();
-                File.Delete(fs.Name);
-                Log.Information(string.Format("Failed packing {0}", dir.Name));
-                return;
+                Log.Error(ex, "Cannot find the dll of ModShardLauncher");
+                return false;
             }
 
-            Write(fs, code.Length);
-            Write(fs, code);
-            Log.Information(string.Format("Successfully packed {0}", dir.Name));
-            fs.Close();
-        }
-        public static void Write(FileStream fs, object obj)
-        {
-            Type type = obj.GetType();
-            if (type == typeof(int))
+            bool resultPacking = false;
+
+            try
             {
-                byte[]? bytes = BitConverter.GetBytes((int)obj);
-                fs.Write(bytes, 0, bytes.Length);
-            }
-            else if(type == typeof(string))
-            {
-                byte[]? bytes = Encoding.UTF8.GetBytes((string)obj);
-                fs.Write(bytes, 0, bytes.Length);
-            }
-            else if(type == typeof(FileInfo))
-            {
-                FileStream stream = new(((FileInfo)obj).FullName, FileMode.Open);
-                byte[]? bytes = new byte[stream.Length];
-                stream.Read(bytes, 0, bytes.Length);
-                fs.Write(bytes, 0, bytes.Length);
-                stream.Close();
-            }
-            else if(type == typeof(byte[]))
-            {
-                fs.Write((byte[])obj);
-            }
-        }
-        public static int CalculateBytesLength(FileInfo f)
-        {
-            FileStream stream = new(f.FullName, FileMode.Open);
-            int len = (int)stream.Length;
-            stream.Close();
-            return len;
-        }
-        public static Diagnostic[] RoslynCompile(string name, IEnumerable<string> files, IEnumerable<string> preprocessorSymbols, out byte[] code, out byte[] pdb)
-        {
-            // creating default namespaces
-            IEnumerable<string> DefaultNamespaces = new[] { "System.Collections.Generic" };
-
-            // creating compilation options
-            CSharpCompilationOptions options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, checkOverflow: true, optimizationLevel: OptimizationLevel.Release, allowUnsafe: false)
-                .WithUsings(DefaultNamespaces);
-
-            // creating parse options
-            CSharpParseOptions parseOptions = new(LanguageVersion.Preview, preprocessorSymbols: preprocessorSymbols);
-
-            // creating emit options
-            EmitOptions emitOptions = new(debugInformationFormat: DebugInformationFormat.PortablePdb);
-
-            // getting all dlls
-            string[] dlls = Directory.GetFiles(Environment.CurrentDirectory, "*.dll");
-
-            // convert string of dll into MetadataReference
-            List<MetadataReference> defaultReferences = dlls
-                .ToList()
-                .ConvertAll(
-                    new Converter<string, MetadataReference>(delegate(string str) { return MetadataReference.CreateFromFile(str); })
+                resultPacking = FilePacker.Pack(
+                    null, 
+                    path, 
+                    ModLoader.ModPath, 
+                    path, 
+                    mslVersion, 
+                    new Type[2] {typeof(ModShardLauncher.Mods.Mod), typeof(UndertaleModLib.Models.UndertaleCode)}
                 );
-
-            // add more references
-            defaultReferences.AddRange(new List<MetadataReference>() { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
-
-            IEnumerable<SyntaxTree> src = files.Select(f => SyntaxFactory.ParseSyntaxTree(File.ReadAllText(f), parseOptions, f, Encoding.UTF8));
-            Log.Information("Compilation: Writting ast...");
-            CSharpCompilation comp = CSharpCompilation.Create(name, src, defaultReferences, options);
-
-            Log.Information("Compilation: used Assemblies...");
-            foreach(MetadataReference usedAssemblyReferences in comp.GetUsedAssemblyReferences())
+            }
+            catch(Exception ex)
             {
-                if (usedAssemblyReferences.Display != null)
+                if (ex is ArgumentNullException || ex is ArgumentException || ex is IOException || ex is DirectoryNotFoundException)
                 {
-                    FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(usedAssemblyReferences.Display);
-                    Log.Information(string.Format("{{{0}}} {{{1}}} {{{2}}}", 
-                        usedAssemblyReferences.Display,
-                        fileVersionInfo.FileVersion,
-                        fileVersionInfo.ProductName
-                    ));
+                    Log.Error(ex.ToString());
                 }
                 else
                 {
-                    Log.Error("Cannot find the assembly");
+                    Log.Error(ex, "Unexpected error");
                 }
-                
+                Console.WriteLine(ex.Message);
+                Log.Error(ex.ToString());
             }
 
-            foreach(SyntaxTree tree in comp.SyntaxTrees)
-            {
-                // get the semantic model for this tree
-                SemanticModel model = comp.GetSemanticModel(tree);
-                
-                // find everywhere in the AST that refers to a type
-                SyntaxNode root = tree.GetRoot();
-                IEnumerable<TypeSyntax> allTypeNames = root.DescendantNodesAndSelf().OfType<TypeSyntax>();
-                
-                foreach(TypeSyntax typeName in allTypeNames)
-                {
-                    // what does roslyn think the type _name_ actually refers to?
-                    Microsoft.CodeAnalysis.TypeInfo effectiveType = model.GetTypeInfo(typeName);
-                    if(effectiveType.Type != null && effectiveType.Type.TypeKind == TypeKind.Error)
-                    {
-                        // if it's an error type (ie. couldn't be resolved), cast and proceed
-                        Log.Error("Cannot understand type {0} of variable {1}", (IErrorTypeSymbol)effectiveType.Type, typeName);
-                    }
-                }
-            }
-
-            using MemoryStream peStream = new();
-            using MemoryStream pdbStream = new();
-
-            EmitResult results = comp.Emit(peStream, pdbStream, options: emitOptions);
-
-            code = peStream.ToArray();
-            pdb = pdbStream.ToArray();
-
-            return results.Diagnostics.ToArray();
-        }
-        public static bool CompileMod(string name, string path, out byte[] code, out byte[] pdb)
-        {
-            IEnumerable<string> files = Directory
-                .GetFiles(path, "*.cs", SearchOption.AllDirectories)
-                .Where(file => !IgnoreCompletely(name, file));
-            
-            Log.Information("Compilation: Gathering files...");
-            Diagnostic[] result = RoslynCompile(name, files, new[] { "FNA" }, out code, out pdb);
-
-            Log.Information("Compilation: Gathering results...");
-            
-            foreach(Diagnostic err in result.Where(e => e.Severity == DiagnosticSeverity.Error))
-            {
-                Log.Error(err.ToString());
-            }
-            foreach(Diagnostic warning in result.Where(e => e.Severity == DiagnosticSeverity.Warning))
-            {
-                Log.Warning(warning.ToString());
-            }
-            foreach(Diagnostic info in result.Where(e => e.Severity == DiagnosticSeverity.Info))
-            {
-                Log.Information(info.ToString());
-            }
-
-            if(Array.Exists(result, e => e.Severity == DiagnosticSeverity.Error))
-            {
-                MessageBox.Show(
-                    string.Format("{0}\nFound {1} error(s), check log for more information.", 
-                    Application.Current.FindResource("CompileError"), 
-                    result.Count(e => e.Severity == DiagnosticSeverity.Error)
-                ));
-                return false;
-            }
-            return true;
-        }
-        public static bool IgnoreCompletely(string name, string file)
-        {
-            string relPath = file.Substring(file.IndexOf("ModSources")).Replace("ModSources\\" + name + "\\", "");
-            return relPath[0] == '.' ||
-                relPath.StartsWith("bin" + Path.DirectorySeparatorChar) ||
-                relPath.StartsWith("obj" + Path.DirectorySeparatorChar);
+            return resultPacking;
         }
     }
 }

--- a/FilePacker.cs
+++ b/FilePacker.cs
@@ -10,21 +10,6 @@ namespace ModShardLauncher
     {
         public static bool Pack(string path)
         {
-            // work around to find the FileVersion of ModShardLauncher.dll for single file publishing
-            // see: https://github.com/dotnet/runtime/issues/13051
-            string mslVersion;
-            try
-            {
-                ProcessModule mainProcess = Msl.ThrowIfNull(Process.GetCurrentProcess().MainModule);
-                string mainProcessName = Msl.ThrowIfNull(mainProcess.FileName);
-                mslVersion = "v" + FileVersionInfo.GetVersionInfo(mainProcessName).FileVersion;
-            }
-            catch(FileNotFoundException ex)
-            {
-                Log.Error(ex, "Cannot find the dll of ModShardLauncher");
-                return false;
-            }
-
             bool resultPacking = false;
 
             try
@@ -34,7 +19,7 @@ namespace ModShardLauncher
                     path, 
                     ModLoader.ModPath, 
                     path, 
-                    mslVersion, 
+                    Main.Instance.mslVersion, 
                     new Type[2] {typeof(ModShardLauncher.Mods.Mod), typeof(UndertaleModLib.Models.UndertaleCode)}
                 );
             }

--- a/FilePacker.cs
+++ b/FilePacker.cs
@@ -8,6 +8,11 @@ namespace ModShardLauncher
 {
     public static class UtilsPacker
     {
+        /// <summary>
+        /// Pack a mod located in <paramref name="path"/> using the packing method from <see cref="ModShardPackerReference"/>.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
         public static bool Pack(string path)
         {
             bool resultPacking = false;
@@ -34,7 +39,6 @@ namespace ModShardLauncher
                     Log.Error(ex, "Unexpected error");
                 }
                 Console.WriteLine(ex.Message);
-                Log.Error(ex.ToString());
             }
 
             return resultPacking;

--- a/FileReader.cs
+++ b/FileReader.cs
@@ -165,7 +165,7 @@ namespace ModShardLauncher
             byte[] versionbytes = Read(fs, size);
 
             file.Version = reg.Replace(Encoding.UTF8.GetString(versionbytes), "$1");
-            Log.Information(string.Format("Reading {{{0}}} built with version {1}", nameMod, file.Version));
+            Log.Information(string.Format("Reading {{{0}}} built with version {{{1}}}", nameMod, file.Version));
 
             // read textures
             int count = BitConverter.ToInt32(Read(fs, 4), 0);

--- a/ModLoader.cs
+++ b/ModLoader.cs
@@ -186,15 +186,9 @@ namespace ModShardLauncher
                 Main.Settings.EnableMods.Add(mod.Name);
                 mod.PatchStatus = PatchStatus.Patching;
 
-                // work around to find the FileVersion of ModShardLauncher.dll for single file publishing
-                // see: https://github.com/dotnet/runtime/issues/13051
-                ProcessModule mainProcess = Msl.ThrowIfNull(Process.GetCurrentProcess().MainModule);
-                string mainProcessName = Msl.ThrowIfNull(mainProcess.FileName);
-                string mod_version = "v" + FileVersionInfo.GetVersionInfo(mainProcessName).FileVersion;
-
-                if (mod.Version != mod_version)
+                if (mod.Version != Main.Instance.mslVersion)
                 {
-                    Log.Warning("Mod {{{0}}} was built with msl {{{1}}} which is different from the current msl {{{2}}}", mod.Name, mod.Version, mod_version);
+                    Log.Warning("Mod {{{0}}} was built with msl {{{1}}} which is different from the current msl {{{2}}}", mod.Name, mod.Version, Main.Instance.mslVersion);
                 }
                 TextureLoader.LoadTextures(mod);
                 mod.instance.PatchMod();

--- a/ModLoader.cs
+++ b/ModLoader.cs
@@ -194,12 +194,7 @@ namespace ModShardLauncher
 
                 if (mod.Version != mod_version)
                 {
-                    MessageBoxResult result = MessageBox.Show(
-                        Application.Current.FindResource("VersionDifferentWarning").ToString(),
-                        Application.Current.FindResource("VersionDifferentWarningTitle").ToString() + " : " + mod.Name, 
-                        MessageBoxButton.OK
-                    );
-                    if (result == MessageBoxResult.No) continue;
+                    Log.Warning("Mod {{{0}}} was built with msl {{{1}}} which is different from the current msl {{{2}}}", mod.Name, mod.Version, mod_version);
                 }
                 TextureLoader.LoadTextures(mod);
                 mod.instance.PatchMod();

--- a/ModLoader.cs
+++ b/ModLoader.cs
@@ -23,9 +23,6 @@ namespace ModShardLauncher
         internal static UndertaleData Data => DataLoader.data;
         public static string ModPath => Path.Join(Environment.CurrentDirectory, "Mods");
         public static string ModSourcesPath => Path.Join(Environment.CurrentDirectory, "ModSources");
-        public static Dictionary<string, ModFile> Mods = new();
-        public static Dictionary<string, ModSource> ModSources = new();
-        private static List<Assembly> Assemblies = new();
         private static List<Menu> Menus = new();
         public static List<string> Weapons = new();
         public static List<string> WeaponDescriptions = new();
@@ -99,9 +96,7 @@ namespace ModShardLauncher
                 i.Stream?.Close();
             
             List<ModFile> modCaches = new();
-            Mods.Clear();
             modSources.Clear();
-            ModSources.Clear();
 
             // List all folders being a C# project
             // Currently only test the existence of a .csproj file
@@ -124,7 +119,6 @@ namespace ModShardLauncher
                     Path = source
                 };
                 modSources.Add(info);
-                ModSources.Add(info.Name, info);
             }
 
             string[] files = Directory.GetFiles(ModPath, "*.sml");
@@ -164,7 +158,6 @@ namespace ModShardLauncher
 
                         modCaches.Add(f);
                     }
-                    Assemblies.Add(assembly);
                 }
                 catch
                 {
@@ -174,7 +167,6 @@ namespace ModShardLauncher
             mods.Clear();
             modCaches.ForEach(i => {
                 mods.Add(i);
-                Mods.Add(i.Name, i);
             });
         }
         public static void PatchMods()

--- a/ModShardLauncher.csproj
+++ b/ModShardLauncher.csproj
@@ -140,6 +140,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="ModShardPackerReference" Version="1.0.3"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />

--- a/ModUtils/CodeUtils.cs
+++ b/ModUtils/CodeUtils.cs
@@ -102,6 +102,12 @@ namespace ModShardLauncher
                 throw;
             }
         }
+        /// <summary>
+        /// Add a new UndertaleCode named <paramref name="name"/> using the code <paramref name="codeAsString"/>. It is expected to be written in GML.
+        /// </summary>
+        /// <param name="codeAsString"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
         public static UndertaleCode AddCode(string codeAsString, string name)
         {
             try
@@ -127,6 +133,12 @@ namespace ModShardLauncher
                 throw;
             }
         }
+        /// <summary>
+        /// Add a new UndertaleCode named <paramref name="name"/> using the code <paramref name="codeAsString"/>. It is expected to be written in ASM abstraction.
+        /// </summary>
+        /// <param name="codeAsString"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
         public static UndertaleCode AddCodeAsm(string codeAsString, string name)
         {
             try

--- a/ModUtils/EventUtils.cs
+++ b/ModUtils/EventUtils.cs
@@ -68,6 +68,10 @@ namespace ModShardLauncher
         {
             return "gml_Object_" + objectName + "_" + eventType + "_" + subtype;
         }
+        public static void AddNewEvent(string objectName, string eventCode, EventType eventType, uint subtype)
+        {
+            AddNewEvent(objectName, eventCode, eventType, subtype, false);
+        }
         /// <summary>
         /// Add a new event (<paramref name="eventType"/>, <paramref name="subtype"/>) associated to an <see cref="UndertaleGameObject"/> named <paramref name="objectName"/>
         /// to the data.win.
@@ -76,7 +80,7 @@ namespace ModShardLauncher
         /// <param name="eventCode"></param>
         /// <param name="eventType"></param>
         /// <param name="subtype"></param>
-        public static void AddNewEvent(string objectName, string eventCode, EventType eventType, uint subtype)
+        public static void AddNewEvent(string objectName, string eventCode, EventType eventType, uint subtype, bool asAsm = false)
         {
             try
             {
@@ -92,7 +96,14 @@ namespace ModShardLauncher
 
                 // create a new code
                 string newEventName = EventName(objectName, eventType, subtype);
-                AddCode(eventCode, newEventName);
+                if (asAsm)
+                {
+                    AddCodeAsm(eventCode, newEventName);
+                }
+                else
+                {
+                    AddCode(eventCode, newEventName);
+                }
                 // add the previous code to the event
                 Event newEvent = new() { EventSubtype = subtype };
                 newEvent.Actions.Add(new EventAction()
@@ -109,6 +120,10 @@ namespace ModShardLauncher
                 throw;
             }
         }
+        public static void AddNewEvent(UndertaleGameObject objectName, string eventCode, EventType eventType, uint subtype)
+        {
+            AddNewEvent(objectName, eventCode, eventType, subtype, false);
+        }
         /// <summary>
         /// Add a new event (<paramref name="eventType"/>, <paramref name="subtype"/>) associated to an <paramref name="gameObject"/>
         /// to the data.win.
@@ -117,7 +132,7 @@ namespace ModShardLauncher
         /// <param name="eventCode"></param>
         /// <param name="eventType"></param>
         /// <param name="subtype"></param>
-        public static void AddNewEvent(UndertaleGameObject gameObject, string eventCode, EventType eventType, uint subtype)
+        public static void AddNewEvent(UndertaleGameObject gameObject, string eventCode, EventType eventType, uint subtype, bool asAsm = false)
         {
             try
             {
@@ -131,7 +146,15 @@ namespace ModShardLauncher
 
                 // create a new code
                 string newEventName = EventName(gameObject.Name.Content, eventType, subtype);
-                AddCode(eventCode, newEventName);
+
+                if (asAsm)
+                {
+                    AddCodeAsm(eventCode, newEventName);
+                }
+                else
+                {
+                    AddCode(eventCode, newEventName);
+                }
                 // add the previous code to the event
                 Event newEvent = new() { EventSubtype = subtype };
                 newEvent.Actions.Add(new EventAction()

--- a/ModUtils/EventUtils.cs
+++ b/ModUtils/EventUtils.cs
@@ -24,9 +24,9 @@ namespace ModShardLauncher
         /// </summary>
         public uint Subtype { get; set; }
         /// <summary>
-        /// Return an complete wrapped event with the name of the file containing its source code.
+        /// Return an abtraction for a UTMT event containing the Event code and its subtype. It also contains either the name of the file containing its source code or the source code itself.
         /// </summary>
-        /// <param name="codeName"></param>
+        /// <param name="code"></param>
         /// <param name="eventType"></param>
         /// <param name="subtype"></param>
         public MslEvent(string code, EventType eventType, uint subtype)
@@ -83,6 +83,11 @@ namespace ModShardLauncher
                 throw;
             }
         }
+        /// <summary>
+        /// Given a <paramref name="gameObject"/>, load the source code of the event and add it in the data.win through the <see cref="AddNewEvent"/> function.
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="modFile"></param>
         public void Apply(UndertaleGameObject objectName)
         {
             try
@@ -109,18 +114,28 @@ namespace ModShardLauncher
         {
             return "gml_Object_" + objectName + "_" + eventType + "_" + subtype;
         }
-        public static void AddNewEvent(string objectName, string eventCode, EventType eventType, uint subtype)
-        {
-            AddNewEvent(objectName, eventCode, eventType, subtype, false);
-        }
         /// <summary>
-        /// Add a new event (<paramref name="eventType"/>, <paramref name="subtype"/>) associated to an <see cref="UndertaleGameObject"/> named <paramref name="objectName"/>
-        /// to the data.win.
+        /// Add a new event (<paramref name="eventType"/>, <paramref name="subtype"/>) associated to an <see cref="UndertaleGameObject"/> named <paramref name="objectName"/>. 
+        /// The code of the event <paramref name="eventCode"/> is expected to be written in GML.
         /// </summary>
         /// <param name="objectName"></param>
         /// <param name="eventCode"></param>
         /// <param name="eventType"></param>
         /// <param name="subtype"></param>
+        /// <param name="asAsm"></param>
+        public static void AddNewEvent(string objectName, string eventCode, EventType eventType, uint subtype)
+        {
+            AddNewEvent(objectName, eventCode, eventType, subtype, false);
+        }
+        /// <summary>
+        /// Add a new event (<paramref name="eventType"/>, <paramref name="subtype"/>) associated to an <see cref="UndertaleGameObject"/> named <paramref name="objectName"/>. 
+        /// The code of the event <paramref name="eventCode"/> can be written in GML or in ASM abstraction. For the later, <see cref="asAsm"/> has to be True.
+        /// </summary>
+        /// <param name="objectName"></param>
+        /// <param name="eventCode"></param>
+        /// <param name="eventType"></param>
+        /// <param name="subtype"></param>
+        /// <param name="asAsm"></param>
         public static void AddNewEvent(string objectName, string eventCode, EventType eventType, uint subtype, bool asAsm = false)
         {
             try
@@ -161,6 +176,14 @@ namespace ModShardLauncher
                 throw;
             }
         }
+        /// <summary>
+        /// Add a new event (<paramref name="eventType"/>, <paramref name="subtype"/>) associated to a <paramref name="gameObject"/>. 
+        /// The code of the event <paramref name="eventCode"/> is expected to be written in GML.
+        /// </summary>
+        /// <param name="objectName"></param>
+        /// <param name="eventCode"></param>
+        /// <param name="eventType"></param>
+        /// <param name="subtype"></param>
         public static void AddNewEvent(UndertaleGameObject objectName, string eventCode, EventType eventType, uint subtype)
         {
             try
@@ -173,8 +196,8 @@ namespace ModShardLauncher
             }
         }
         /// <summary>
-        /// Add a new event (<paramref name="eventType"/>, <paramref name="subtype"/>) associated to an <paramref name="gameObject"/>
-        /// to the data.win.
+        /// Add a new event (<paramref name="eventType"/>, <paramref name="subtype"/>) associated to a <paramref name="gameObject"/>. 
+        /// The code of the event <paramref name="eventCode"/> can be written in GML or in ASM abstraction. For the later, <see cref="asAsm"/> has to be True.
         /// </summary>
         /// <param name="gameObject"></param>
         /// <param name="eventCode"></param>

--- a/ModUtils/EventUtils.cs
+++ b/ModUtils/EventUtils.cs
@@ -14,7 +14,7 @@ namespace ModShardLauncher
         /// <summary>
         /// File where the code of the event is stored.
         /// </summary>
-        public string CodeName { get; set; }
+        public string Code { get; set; }
         /// <summary>
         /// The <see cref="EventType"/> of the event.
         /// </summary>
@@ -29,9 +29,9 @@ namespace ModShardLauncher
         /// <param name="codeName"></param>
         /// <param name="eventType"></param>
         /// <param name="subtype"></param>
-        public MslEvent(string codeName, EventType eventType, uint subtype)
+        public MslEvent(string code, EventType eventType, uint subtype)
         {
-            CodeName = codeName;
+            Code = code;
             EventType = eventType;
             Subtype = subtype;
         }
@@ -42,7 +42,14 @@ namespace ModShardLauncher
         /// <param name="modFile"></param>
         public void Apply(string objectName, ModFile modFile)
         {
-            Msl.AddNewEvent(objectName, modFile.GetCode(CodeName), EventType, Subtype);
+            try
+            {
+                Msl.AddNewEvent(objectName, modFile.GetCode(Code), EventType, Subtype);
+            }
+            catch
+            {
+                throw;
+            }
         }
         /// <summary>
         /// Given a <paramref name="gameObject"/>, load the source code of the event and add it in the data.win through the <see cref="AddNewEvent"/> function.
@@ -51,7 +58,41 @@ namespace ModShardLauncher
         /// <param name="modFile"></param>
         public void Apply(UndertaleGameObject gameObject, ModFile modFile)
         {
-            Msl.AddNewEvent(gameObject, modFile.GetCode(CodeName), EventType, Subtype);
+            try
+            {
+                Msl.AddNewEvent(gameObject, modFile.GetCode(Code), EventType, Subtype);
+            }
+            catch
+            {
+                throw;
+            }
+        }
+        /// <summary>
+        /// Given an <see cref="UndertaleGameObject"/> named <paramref name="objectName"/>, load the source code of the event and add it in the data.win through the <see cref="AddNewEvent"/> function.
+        /// </summary>
+        /// <param name="objectName"></param>
+        /// <param name="modFile"></param>
+        public void Apply(string objectName)
+        {
+            try
+            {
+                Msl.AddNewEvent(objectName, Code, EventType, Subtype);
+            }
+            catch
+            {
+                throw;
+            }
+        }
+        public void Apply(UndertaleGameObject objectName)
+        {
+            try
+            {
+                Msl.AddNewEvent(objectName, Code, EventType, Subtype);
+            }
+            catch
+            {
+                throw;
+            }
         }
     }
     public static partial class Msl
@@ -122,7 +163,14 @@ namespace ModShardLauncher
         }
         public static void AddNewEvent(UndertaleGameObject objectName, string eventCode, EventType eventType, uint subtype)
         {
-            AddNewEvent(objectName, eventCode, eventType, subtype, false);
+            try
+            {
+                AddNewEvent(objectName, eventCode, eventType, subtype, false);
+            }
+            catch
+            {
+                throw;
+            }
         }
         /// <summary>
         /// Add a new event (<paramref name="eventType"/>, <paramref name="subtype"/>) associated to an <paramref name="gameObject"/>

--- a/ModUtils/EventUtils.cs
+++ b/ModUtils/EventUtils.cs
@@ -122,7 +122,6 @@ namespace ModShardLauncher
         /// <param name="eventCode"></param>
         /// <param name="eventType"></param>
         /// <param name="subtype"></param>
-        /// <param name="asAsm"></param>
         public static void AddNewEvent(string objectName, string eventCode, EventType eventType, uint subtype)
         {
             AddNewEvent(objectName, eventCode, eventType, subtype, false);

--- a/ModUtils/ObjectUtils.cs
+++ b/ModUtils/ObjectUtils.cs
@@ -34,7 +34,7 @@ namespace ModShardLauncher
         /// Extension method to apply several <see cref="MslEvent"/> to a <see cref="gameObject"/> simultaneously. It is expected that all MslEvent.Code contain their code directly.
         /// <example>For example:
         /// <code>
-        /// gameObject.ApplyEvent(ModFiles, 
+        /// gameObject.ApplyEvent(
         ///     new MslEvent(code0, EventType.Create, 0),
         ///     new MslEvent(code1, EventType.Other, 10),
         ///     new MslEvent(code2, EventType.Other, 11)
@@ -43,7 +43,6 @@ namespace ModShardLauncher
         /// </example>
         /// </summary>
         /// <param name="gameObject"></param>
-        /// <param name="modFile"></param>
         /// <param name="mslEvents"></param>
         static public void ApplyEvent(this UndertaleGameObject gameObject, params MslEvent[] mslEvents)
         {

--- a/ModUtils/ObjectUtils.cs
+++ b/ModUtils/ObjectUtils.cs
@@ -30,6 +30,28 @@ namespace ModShardLauncher
                 mslEvent.Apply(gameObject, modFile);
             }
         }
+        /// <summary>
+        /// Extension method to apply several <see cref="MslEvent"/> to a <see cref="gameObject"/> simultaneously.
+        /// <example>For example:
+        /// <code>
+        /// gameObject.ApplyEvent(ModFiles, 
+        ///     new MslEvent(code0, EventType.Create, 0),
+        ///     new MslEvent(code1, EventType.Other, 10),
+        ///     new MslEvent(code2, EventType.Other, 11)
+        /// );
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="modFile"></param>
+        /// <param name="mslEvents"></param>
+        static public void ApplyEvent(this UndertaleGameObject gameObject, params MslEvent[] mslEvents)
+        {
+            foreach (MslEvent mslEvent in mslEvents)
+            {
+                mslEvent.Apply(gameObject);
+            }
+        }
     }
     public static partial class Msl
     {

--- a/ModUtils/ObjectUtils.cs
+++ b/ModUtils/ObjectUtils.cs
@@ -9,7 +9,7 @@ namespace ModShardLauncher
     public static class GameObjectUtils
     {
         /// <summary>
-        /// Extension method to apply several <see cref="MslEvent"/> to a <see cref="gameObject"/> simultaneously.
+        /// Extension method to apply several <see cref="MslEvent"/> to a <see cref="gameObject"/> simultaneously. It is expected that all MslEvent.Code contain the path of their code.
         /// <example>For example:
         /// <code>
         /// gameObject.ApplyEvent(ModFiles, 
@@ -31,7 +31,7 @@ namespace ModShardLauncher
             }
         }
         /// <summary>
-        /// Extension method to apply several <see cref="MslEvent"/> to a <see cref="gameObject"/> simultaneously.
+        /// Extension method to apply several <see cref="MslEvent"/> to a <see cref="gameObject"/> simultaneously. It is expected that all MslEvent.Code contain their code directly.
         /// <example>For example:
         /// <code>
         /// gameObject.ApplyEvent(ModFiles, 
@@ -55,6 +55,13 @@ namespace ModShardLauncher
     }
     public static partial class Msl
     {
+        /// <summary>
+        /// Add and return a new <see cref="UndertaleGameObject"/> named <paramref name="name"/> to the data.win if this name is not used already.
+        /// Else return the existing <see cref="UndertaleGameObject"/>.
+        /// This methods does not allow any parametrization when creating this <see cref="UndertaleGameObject"/>.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
         public static UndertaleGameObject AddObject(string name)
         {
             return AddObject(


### PR DESCRIPTION
# Maintainer changelog

- Logs the version of MSL when launching the App and stores it, preventing the need to recompute the MSL version during patching.
- Logs a warning if the checksum of the data.win being loaded is different from the vanilla gog and steam version [ experimental ].
- Adds a minimal workflow to produce a prerelease when a tag is pushed [ not tested ].
- Uses the packer module from MSPref instead of its own packing. From now on MSL and MSP will rely on the same packing algorithm [ warning: a new dependancy is needed to compile MSL ].
- Removes some legacy code.
- Logs the list of mods applied to a data.win even if the patching is successful. In previous version, it was only log if the patching failed.

# Modder changelog

- Adds a way to inject multiple events to a unique GameObject at once by providing the code of said events directly. In previous version you could to the same but by providing the path where to find said events in the mod folder.
- Adds new methods to create a new code from ASM abstraction and to create a new event by giving ASM abstraction instead of relying exclusively on GML.

# User changelog

- Removes the warning window when patching a mod built with a different version of MSL and logs it as a warning instead.